### PR TITLE
Use source fileName to name convertes .scad file

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,10 @@
 	<span id="result"></span>
 
 	<div>
-		<a href="#" id="download" class="button" style="display: none">Download</a>
+		<a href="#" id="download" class="button" style="display: none">
+			Download
+			<span id="fileName"></span>
+		</a>
 	</div>
 	<script src="js/main.js"></script>
 

--- a/js/main.js
+++ b/js/main.js
@@ -303,7 +303,8 @@ function handleFileSelect(evt) {
       progress.style.width = '100%';
       progress.textContent = '100%';
       setTimeout("document.getElementById('progress_bar').className='';", 2000);
-      fileName = nextFileName;
+      fileName = nextFileName.slice(0, -4);
+      document.getElementById('fileName').textContent = fileName;    
       parseResult(reader.result);
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -304,7 +304,7 @@ function handleFileSelect(evt) {
       progress.textContent = '100%';
       setTimeout("document.getElementById('progress_bar').className='';", 2000);
       fileName = nextFileName.slice(0, -4);
-      document.getElementById('fileName').textContent = fileName;    
+      document.getElementById('fileName').textContent = " " + fileName + ".scad";    
       parseResult(reader.result);
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -286,8 +286,8 @@ function handleFileSelect(evt) {
   progress.style.width = '0%';
   progress.textContent = '0%';
   
-  filename = evt.target.files[0].name;
-  var extension = String(filename.match(/\.[0-9a-z]+$/i));
+  var nextFileName = evt.target.files[0].name;
+  var extension = String(nextFileName.match(/\.[0-9a-z]+$/i));
   if (extension.toLowerCase() == ".stl") {
     reader = new FileReader();
     reader.onerror = errorHandler;
@@ -305,6 +305,7 @@ function handleFileSelect(evt) {
       progress.textContent = '100%';
       setTimeout("document.getElementById('progress_bar').className='';", 2000);
       parseResult(reader.result);
+      fileName = nextFileName;
   }
 
   // Read in the stl file as a binary string.

--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,6 @@ function _reset() {
   vertexIndex = 0;
   converted = 0;
   totalObjects = 0;
-  fileName = '';
   document.getElementById('error').innerText = '';
   document.getElementById('conversion').innerText = '';
   document.getElementById("download").style.display = "none"
@@ -304,8 +303,8 @@ function handleFileSelect(evt) {
       progress.style.width = '100%';
       progress.textContent = '100%';
       setTimeout("document.getElementById('progress_bar').className='';", 2000);
-      parseResult(reader.result);
       fileName = nextFileName;
+      parseResult(reader.result);
   }
 
   // Read in the stl file as a binary string.

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ var vertexIndex = 0;
 var converted = 0;
 var totalObjects = 0;
 var convertedObjects = 0;
+var fileName = '';
 
 function _reset() {
   vertices = [];
@@ -23,6 +24,7 @@ function _reset() {
   vertexIndex = 0;
   converted = 0;
   totalObjects = 0;
+  fileName = '';
   document.getElementById('error').innerText = '';
   document.getElementById('conversion').innerText = '';
   document.getElementById("download").style.display = "none"
@@ -243,7 +245,7 @@ function saveResult(vertices, triangles, boundsMin, boundsMax) {
   });
 
   $("#download").attr("href", window.URL.createObjectURL(blob));
-  $("#download").attr("download", "FromSTL.scad");
+  $("#download").attr("download", fileName + ".scad");
 
   document.getElementById("conversion").innerText = "Conversion complete. Click the button below to download your OpenSCAD file!";
   document.getElementById("triangles").innerText = "Total Triangles: " + triangles.length;
@@ -284,7 +286,7 @@ function handleFileSelect(evt) {
   progress.style.width = '0%';
   progress.textContent = '0%';
   
-  var filename = evt.target.files[0].name;
+  filename = evt.target.files[0].name;
   var extension = String(filename.match(/\.[0-9a-z]+$/i));
   if (extension.toLowerCase() == ".stl") {
     reader = new FileReader();


### PR DESCRIPTION
- uses the filename of the .stl file to name the converted .scad file
- name is also shown in Download button
- This makes organization easier, especially when converting multiple files in a row

demo on https://xipit.github.io/STL-to-OpenSCAD-Converter/ 